### PR TITLE
Adds path parameter to push from subdirectory

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -11,6 +11,7 @@ The following parameters are used to configure the plugin:
 * **remote_name** - name of the remote to use locally (default "deploy")
 * **branch** - target remote branch, defaults to master
 * **local_branch** - local branch or ref to push (default "HEAD")
+* **path** - path to git repo (if blank, assume current directory)
 * **force** - force push using the `--force` flag, defaults to false
 * **skip_verify** - skip verification of HTTPS certs, defaults to false
 * **commit** - add and commit the contents of the repo before pushing, defaults to false
@@ -61,4 +62,16 @@ pipeline:
     remote_name: origin
     branch: gh-pages
     local_ref: gh-pages
+```
+
+An example of specifying the path to a repo:
+
+```yaml
+pipeline:
+  git_push:
+    image: appleboy/drone-git-push
+    remote_name: origin
+    branch: gh-pages
+    local_ref: gh-pages
+    path: path/to/repo
 ```

--- a/main.go
+++ b/main.go
@@ -71,6 +71,11 @@ func main() {
 			Value:  "HEAD",
 			EnvVar: "PLUGIN_LOCAL_BRANCH,GIT_PUSH_LOCAL_BRANCH",
 		},
+		cli.StringFlag{
+			Name:   "path",
+			Usage:  "path to git repo",
+			EnvVar: "PLUGIN_PATH",
+		},
 		cli.BoolFlag{
 			Name:   "force",
 			Usage:  "force push to remote",
@@ -130,6 +135,7 @@ func run(c *cli.Context) error {
 			RemoteName:    c.String("remote-name"),
 			Branch:        c.String("branch"),
 			LocalBranch:   c.String("local-branch"),
+			Path:          c.String("path"),
 			Force:         c.Bool("force"),
 			SkipVerify:    c.Bool("skip-verify"),
 			Commit:        c.Bool("commit"),

--- a/plugin.go
+++ b/plugin.go
@@ -130,6 +130,7 @@ func (p Plugin) HandleRemote() error {
 	return nil
 }
 
+// HandlePath changes to a different directory if required
 func (p Plugin) HandlePath() error {
 	if p.Config.Path != "" {
 		if err := os.Chdir(p.Config.Path); err != nil {

--- a/plugin.go
+++ b/plugin.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"github.com/appleboy/drone-git-push/repo"
+	"os"
 )
 
 type (
@@ -30,6 +31,7 @@ type (
 		RemoteName    string
 		Branch        string
 		LocalBranch   string
+		Path          string
 		Force         bool
 		SkipVerify    bool
 		Commit        bool
@@ -47,6 +49,10 @@ type (
 
 // Exec starts the plugin execution.
 func (p Plugin) Exec() error {
+	if err := p.HandlePath(); err != nil {
+		return err
+	}
+
 	if err := p.WriteConfig(); err != nil {
 		return err
 	}
@@ -117,6 +123,16 @@ func (p Plugin) WriteNetrc() error {
 func (p Plugin) HandleRemote() error {
 	if p.Config.Remote != "" {
 		if err := execute(repo.RemoteAdd(p.Config.RemoteName, p.Config.Remote)); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (p Plugin) HandlePath() error {
+	if p.Config.Path != "" {
+		if err := os.Chdir(p.Config.Path); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
This PR adds the ability for users to specify a path to the repo that they wish to push, instead of only allowing pushes from the workspace directory. This is accomplished using the `path` parameter in a .drone.yml, as shown below:

```
pipeline:
  git_push:
    image: appleboy/drone-git-push
    remote_name: origin
    branch: gh-pages
    local_ref: gh-pages
    path: path/to/repo
```