### PR TITLE
Change git commit logic so empty commits do not cause errors.

### DIFF
--- a/plugin.go
+++ b/plugin.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"github.com/appleboy/drone-git-push/repo"
+	"drone-git-push/repo"
 	"os"
 )
 
@@ -144,17 +144,21 @@ func (p Plugin) HandlePath() error {
 // HandleCommit commits dirty changes if required.
 func (p Plugin) HandleCommit() error {
 	if p.Config.Commit {
-		if p.Config.EmptyCommit {
-			if err := execute(repo.EmptyCommit(p.Config.CommitMessage)); err != nil {
-				return err
-			}
-		} else {
-			if err := execute(repo.ForceAdd()); err != nil {
-				return err
-			}
+		if err := execute(repo.Add()); err != nil {
+			return err
+		}
 
+		if err := execute(repo.TestCleanTree()); err != nil {
+			// changes to commit
 			if err := execute(repo.ForceCommit(p.Config.CommitMessage)); err != nil {
 				return err
+			}
+		} else { // no changes
+			if p.Config.EmptyCommit {
+				// no changes but commit anyway
+				if err := execute(repo.EmptyCommit(p.Config.CommitMessage)); err != nil {
+					return err
+				}
 			}
 		}
 	}

--- a/plugin.go
+++ b/plugin.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"drone-git-push/repo"
+	"github.com/appleboy/drone-git-push/repo"
 	"os"
 )
 

--- a/repo/commit.go
+++ b/repo/commit.go
@@ -18,6 +18,7 @@ func ForceAdd() *exec.Cmd {
 	return cmd
 }
 
+// Add updates the index to match the working tree.
 func Add() *exec.Cmd {
 	cmd := exec.Command(
 		"git",
@@ -27,6 +28,7 @@ func Add() *exec.Cmd {
 	return cmd
 }
 
+// TestCleanTree returns non-zero if diff between index and local repository
 func TestCleanTree() *exec.Cmd {
 	cmd := exec.Command(
 		"git",

--- a/repo/commit.go
+++ b/repo/commit.go
@@ -18,6 +18,26 @@ func ForceAdd() *exec.Cmd {
 	return cmd
 }
 
+func Add() *exec.Cmd {
+	cmd := exec.Command(
+		"git",
+		"add",
+		"--all")
+
+	return cmd
+}
+
+func TestCleanTree() *exec.Cmd {
+	cmd := exec.Command(
+		"git",
+		"diff-index",
+		"--quiet",
+		"HEAD",
+		"--ignore-submodules")
+
+	return cmd
+}
+
 // EmptyCommit simply create an empty commit
 func EmptyCommit(msg string) *exec.Cmd {
 	if msg == "" {


### PR DESCRIPTION
Previously, the only way to handle an empty commit is to set `empty_commit` to true, in which case all commits are empty, even if there are changes that need to be committed.

This will `git add --all`, then check the index to see if there is anything to commit, if so it will proceed with the commit, if not, it will only make an empty commit if `empty_commit` has been set to true.

