### PR TITLE
Note author_ config options

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -17,6 +17,8 @@ The following parameters are used to configure the plugin:
 * **commit** - add and commit the contents of the repo before pushing, defaults to false
 * **commit_message** - add a custom message for commit, if it is omitted, it will be `[skip ci] Commit dirty state`
 * **empty_commit** - if you only want generate an empty commit, you can do it using this option
+* **author_name** - the name to use for the author of the commit (if blank, assume push commiter name)
+* **author_email** - the email address to use for the author of the commit (if blank, assume push commiter name)
 
 The following secret values can be set to configure the plugin.
 


### PR DESCRIPTION
Currently `author_name` and `author_email` are undocumented.

I wanted to be able to modify these, and was pleasantly surprised to find they existed despite not being documented. 

I'm flexible on the wording, I just would like them documented so others don't have to dig into the code to realize they exist.