### PR TITLE
Inject available env variables into commands

### DIFF
--- a/utils.go
+++ b/utils.go
@@ -10,6 +10,7 @@ import (
 func execute(cmd *exec.Cmd) error {
 	fmt.Println("+", strings.Join(cmd.Args, " "))
 
+	cmd.Env = os.Environ()
 	cmd.Stderr = os.Stderr
 	cmd.Stdin = os.Stdin
 


### PR DESCRIPTION
I am injecting the available envionment variables into the git commands,
  that way git hooks can check for various env variables, like if the CI
  variable exists it can skip some pre-commit hooks.