### PR TITLE
Fix usage documentation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,11 +35,11 @@ Execute from the working directory:
 docker run --rm \
   -e DRONE_COMMIT_AUTHOR=Octocat \
   -e DRONE_COMMIT_AUTHOR_EMAIL=octocat@github.com \
-  -e PLUGIN_SSH_KEY=${HOME}/.ssh/id_rsa \
+  -e PLUGIN_SSH_KEY="$(cat "${HOME}/.ssh/id_rsa")" \
   -e PLUGIN_BRANCH=master \
   -e PLUGIN_REMOTE=git@github.com:foo/bar.git \
   -e PLUGIN_FORCE=false \
-  -v $(pwd)/$(pwd) \
-  -w $(pwd) \
+  -v "$(pwd):$(pwd)" \
+  -w "$(pwd)" \
   appleboy/drone-git-push
 ```


### PR DESCRIPTION
PLUGIN_SSH_KEY needs to be set to the content of the private key not to
its path.

The syntax for mounting a volume uses a colon not a slash.

$(pwd) invocations should be quoted to work in directories with a space
in the path.