### PR TITLE
Add git username and password auth

### DIFF
--- a/main.go
+++ b/main.go
@@ -44,17 +44,17 @@ func main() {
 		&cli.StringFlag{
 			Name:    "netrc.machine",
 			Usage:   "netrc machine",
-			EnvVars: []string{"DRONE_NETRC_MACHINE"},
+			EnvVars: []string{"PLUGIN_NETRC_MACHINE,DRONE_NETRC_MACHINE"},
 		},
 		&cli.StringFlag{
 			Name:    "netrc.username",
 			Usage:   "netrc username",
-			EnvVars: []string{"DRONE_NETRC_USERNAME"},
+			EnvVars: []string{"PLUGIN_USERNAME,DRONE_NETRC_USERNAME,GITHUB_USERNAME"},
 		},
 		&cli.StringFlag{
 			Name:    "netrc.password",
 			Usage:   "netrc password",
-			EnvVars: []string{"DRONE_NETRC_PASSWORD"},
+			EnvVars: []string{"PLUGIN_PASSWORD,DRONE_NETRC_PASSWORD,GITHUB_PASSWORD"},
 		},
 		&cli.StringFlag{
 			Name:    "ssh-key",


### PR DESCRIPTION
Currently, the git username and password are set using the defaults from `DRONE_NETRC`. This sometimes run into issues when pushing to GitHub as the plugin cannot interact with the command line prompt.

[drone-gh-pages](https://github.com/drone-plugins/drone-gh-pages/blob/3faf0fd352b127860590de858100f48d62dabb08/main.go#L86-L101) solves this by allowing the user to set the username and password through settings.

I port over those options here so the netrc settings match functionality between the two plugins.

Note that the original commit that added authentication to drone-gh-pages also added [better error handling](https://github.com/drone-plugins/drone-gh-pages/commit/eff977ea8c6fd23f3f0ecffc54835c5479ae4c79). I haven't added that code here because I am not sure if that is needed/wanted.