### PR TITLE
Fix loading netrc flags from environment

### DIFF
--- a/main.go
+++ b/main.go
@@ -44,17 +44,17 @@ func main() {
 		&cli.StringFlag{
 			Name:    "netrc.machine",
 			Usage:   "netrc machine",
-			EnvVars: []string{"PLUGIN_NETRC_MACHINE,DRONE_NETRC_MACHINE"},
+			EnvVars: []string{"PLUGIN_NETRC_MACHINE", "DRONE_NETRC_MACHINE"},
 		},
 		&cli.StringFlag{
 			Name:    "netrc.username",
 			Usage:   "netrc username",
-			EnvVars: []string{"PLUGIN_USERNAME,DRONE_NETRC_USERNAME,GITHUB_USERNAME"},
+			EnvVars: []string{"PLUGIN_USERNAME", "DRONE_NETRC_USERNAME", "GITHUB_USERNAME"},
 		},
 		&cli.StringFlag{
 			Name:    "netrc.password",
 			Usage:   "netrc password",
-			EnvVars: []string{"PLUGIN_PASSWORD,DRONE_NETRC_PASSWORD,GITHUB_PASSWORD"},
+			EnvVars: []string{"PLUGIN_PASSWORD", "DRONE_NETRC_PASSWORD", "GITHUB_PASSWORD"},
 		},
 		&cli.StringFlag{
 			Name:    "ssh-key",


### PR DESCRIPTION
Since 1aa722ba5c63bf4c5985069e478b2cf9c1ab6919, the flags netrc.{machine,username,password} can't be loaded from the environment anymore. This pull request fixes this and closes #54.