### PR TITLE
chore(commit): Forcibly set the author when committing

### DIFF
--- a/plugin.go
+++ b/plugin.go
@@ -171,13 +171,13 @@ func (p Plugin) HandleCommit() error {
 
 		if err := execute(repo.TestCleanTree()); err != nil {
 			// changes to commit
-			if err := execute(repo.ForceCommit(p.Config.CommitMessage, p.Config.NoVerify)); err != nil {
+			if err := execute(repo.ForceCommit(p.Config.CommitMessage, p.Config.NoVerify, p.Commit.Author.Name, p.Commit.Author.Email)); err != nil {
 				return err
 			}
 		} else { // no changes
 			if p.Config.EmptyCommit {
 				// no changes but commit anyway
-				if err := execute(repo.EmptyCommit(p.Config.CommitMessage, p.Config.NoVerify)); err != nil {
+				if err := execute(repo.EmptyCommit(p.Config.CommitMessage, p.Config.NoVerify, p.Commit.Author.Name, p.Commit.Author.Email)); err != nil {
 					return err
 				}
 			}

--- a/repo/commit.go
+++ b/repo/commit.go
@@ -1,6 +1,7 @@
 package repo
 
 import (
+	"fmt"
 	"os/exec"
 )
 
@@ -53,7 +54,7 @@ func TestCleanTree() *exec.Cmd {
 }
 
 // EmptyCommit simply create an empty commit
-func EmptyCommit(msg string, noVerify bool) *exec.Cmd {
+func EmptyCommit(msg string, noVerify bool, authorName, authorEmail string) *exec.Cmd {
 	if msg == "" {
 		msg = defaultCommitMessage
 	}
@@ -72,11 +73,17 @@ func EmptyCommit(msg string, noVerify bool) *exec.Cmd {
 			"--no-verify")
 	}
 
+	if authorName != "" || authorEmail != "" {
+		cmd.Args = append(
+			cmd.Args,
+			fmt.Sprintf("-a=\"%q <%q>\"", authorName, authorEmail))
+	}
+
 	return cmd
 }
 
 // ForceCommit commits every change while skipping CI.
-func ForceCommit(msg string, noVerify bool) *exec.Cmd {
+func ForceCommit(msg string, noVerify bool, authorName, authorEmail string) *exec.Cmd {
 	if msg == "" {
 		msg = defaultCommitMessage
 	}
@@ -92,6 +99,12 @@ func ForceCommit(msg string, noVerify bool) *exec.Cmd {
 		cmd.Args = append(
 			cmd.Args,
 			"--no-verify")
+	}
+
+	if authorName != "" || authorEmail != "" {
+		cmd.Args = append(
+			cmd.Args,
+			fmt.Sprintf("-a=\"%q <%q>\"", authorName, authorEmail))
 	}
 
 	return cmd


### PR DESCRIPTION
Although the plugin attempts to set the global author values this does not work and commits are still having their author default to the last committer.

Instead we should explicitly set the author to the provided configuration value on commit.

Signed-off-by: Andrew Thornton <art27@cantab.net>