### PR TITLE
Fix(git): Replaced -a with --author and remove false quote marks.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # drone-git-push
 
 [![GoDoc](https://godoc.org/github.com/appleboy/drone-git-push?status.svg)](https://godoc.org/github.com/appleboy/drone-git-push)
-[![Lint and Testing](https://github.com/appleboy/drone-git-push/actions/workflows/lint.yml/badge.svg)](https://github.com/appleboy/drone-git-push/actions/workflows/lint.yml)
-[![codecov](https://codecov.io/gh/appleboy/drone-git-push/branch/master/graph/badge.svg)](https://codecov.io/gh/appleboy/drone-git-push)
-[![Go Report Card](https://goreportcard.com/badge/github.com/appleboy/drone-git-push)](https://goreportcard.com/report/github.com/appleboy/drone-git-push)
-[![Docker Pulls](https://img.shields.io/docker/pulls/appleboy/drone-git-push.svg)](https://hub.docker.com/r/appleboy/drone-git-push/)
+[![Lint and Testing](https://github.com/JonasBernard/drone-git-push/actions/workflows/lint.yml/badge.svg)](https://github.com/JonasBernard/drone-git-push/actions/workflows/lint.yml)
+[![codecov](https://codecov.io/gh/JonasBernard/drone-git-push/branch/master/graph/badge.svg)](https://codecov.io/gh/JonasBernard/drone-git-push)
+[![Go Report Card](https://goreportcard.com/badge/github.com/JonasBernard/drone-git-push)](https://goreportcard.com/report/github.com/JonasBernard/drone-git-push)
+[![Docker Pulls](https://img.shields.io/docker/pulls/jonasbernard/drone-git-push.svg)](https://hub.docker.com/r/jonasbernard/drone-git-push/)
 
 [Drone](https://www.drone.io/) / [Woodpecker](https://woodpecker-ci.org/) plugin to push changes to a remote `git` repository.
 For the usage information and a listing of the available options please take a look at [the docs](DOCS.md).

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # drone-git-push
 
 [![GoDoc](https://godoc.org/github.com/appleboy/drone-git-push?status.svg)](https://godoc.org/github.com/appleboy/drone-git-push)
-[![Lint and Testing](https://github.com/JonasBernard/drone-git-push/actions/workflows/lint.yml/badge.svg)](https://github.com/JonasBernard/drone-git-push/actions/workflows/lint.yml)
-[![codecov](https://codecov.io/gh/JonasBernard/drone-git-push/branch/master/graph/badge.svg)](https://codecov.io/gh/JonasBernard/drone-git-push)
-[![Go Report Card](https://goreportcard.com/badge/github.com/JonasBernard/drone-git-push)](https://goreportcard.com/report/github.com/JonasBernard/drone-git-push)
-[![Docker Pulls](https://img.shields.io/docker/pulls/jonasbernard/drone-git-push.svg)](https://hub.docker.com/r/jonasbernard/drone-git-push/)
+[![Lint and Testing](https://github.com/appleboy/drone-git-push/actions/workflows/lint.yml/badge.svg)](https://github.com/appleboy/drone-git-push/actions/workflows/lint.yml)
+[![codecov](https://codecov.io/gh/appleboy/drone-git-push/branch/master/graph/badge.svg)](https://codecov.io/gh/appleboy/drone-git-push)
+[![Go Report Card](https://goreportcard.com/badge/github.com/appleboy/drone-git-push)](https://goreportcard.com/report/github.com/appleboy/drone-git-push)
+[![Docker Pulls](https://img.shields.io/docker/pulls/appleboy/drone-git-push.svg)](https://hub.docker.com/r/appleboy/drone-git-push/)
 
 [Drone](https://www.drone.io/) / [Woodpecker](https://woodpecker-ci.org/) plugin to push changes to a remote `git` repository.
 For the usage information and a listing of the available options please take a look at [the docs](DOCS.md).

--- a/repo/commit.go
+++ b/repo/commit.go
@@ -3,7 +3,7 @@ package repo
 import (
 	"fmt"
 	"os/exec"
-	"string"
+	"strings"
 )
 
 const defaultCommitMessage = "[skip ci] Commit dirty state"
@@ -77,7 +77,7 @@ func EmptyCommit(msg string, noVerify bool, authorName, authorEmail string) *exe
 	if authorName != "" || authorEmail != "" {
 		cmd.Args = append(
 			cmd.Args,
-			fmt.Sprintf("-a=\"%q <%q>\"", authorName, authorEmail))
+			fmt.Sprintf("--auther=\"%q <%q>\"", strings.Trim(authorName, "\""), strings.Trim(authorEmail, "\"")))
 	}
 
 	return cmd

--- a/repo/commit.go
+++ b/repo/commit.go
@@ -3,6 +3,7 @@ package repo
 import (
 	"fmt"
 	"os/exec"
+	"string"
 )
 
 const defaultCommitMessage = "[skip ci] Commit dirty state"
@@ -104,7 +105,7 @@ func ForceCommit(msg string, noVerify bool, authorName, authorEmail string) *exe
 	if authorName != "" || authorEmail != "" {
 		cmd.Args = append(
 			cmd.Args,
-			fmt.Sprintf("--auther=\"%q <%q>\"", authorName, authorEmail))
+			fmt.Sprintf("--auther=\"%q <%q>\"", strings.Trim(authorName, "\""), strings.Trim(authorEmail, "\"")))
 	}
 
 	return cmd

--- a/repo/commit.go
+++ b/repo/commit.go
@@ -77,7 +77,7 @@ func EmptyCommit(msg string, noVerify bool, authorName, authorEmail string) *exe
 	if authorName != "" || authorEmail != "" {
 		cmd.Args = append(
 			cmd.Args,
-			fmt.Sprintf("--auther=\"%q <%q>\"", strings.Trim(authorName, "\""), strings.Trim(authorEmail, "\"")))
+			fmt.Sprintf("--author=\"%q <%q>\"", strings.Trim(authorName, "\""), strings.Trim(authorEmail, "\"")))
 	}
 
 	return cmd
@@ -105,7 +105,7 @@ func ForceCommit(msg string, noVerify bool, authorName, authorEmail string) *exe
 	if authorName != "" || authorEmail != "" {
 		cmd.Args = append(
 			cmd.Args,
-			fmt.Sprintf("--auther=\"%q <%q>\"", strings.Trim(authorName, "\""), strings.Trim(authorEmail, "\"")))
+			fmt.Sprintf("--author=\"%q <%q>\"", strings.Trim(authorName, "\""), strings.Trim(authorEmail, "\"")))
 	}
 
 	return cmd

--- a/repo/commit.go
+++ b/repo/commit.go
@@ -3,7 +3,6 @@ package repo
 import (
 	"fmt"
 	"os/exec"
-	"strings"
 )
 
 const defaultCommitMessage = "[skip ci] Commit dirty state"
@@ -77,7 +76,7 @@ func EmptyCommit(msg string, noVerify bool, authorName, authorEmail string) *exe
 	if authorName != "" || authorEmail != "" {
 		cmd.Args = append(
 			cmd.Args,
-			fmt.Sprintf("--author=\"%q <%q>\"", strings.Trim(authorName, "\""), strings.Trim(authorEmail, "\"")))
+			fmt.Sprintf("--author=\"%s <%q>\"", authorName, authorEmail))
 	}
 
 	return cmd
@@ -105,7 +104,7 @@ func ForceCommit(msg string, noVerify bool, authorName, authorEmail string) *exe
 	if authorName != "" || authorEmail != "" {
 		cmd.Args = append(
 			cmd.Args,
-			fmt.Sprintf("--author=\"%q <%q>\"", strings.Trim(authorName, "\""), strings.Trim(authorEmail, "\"")))
+			fmt.Sprintf("--author=\"%s <%s>\"", authorName, authorEmail))
 	}
 
 	return cmd

--- a/repo/commit.go
+++ b/repo/commit.go
@@ -104,7 +104,7 @@ func ForceCommit(msg string, noVerify bool, authorName, authorEmail string) *exe
 	if authorName != "" || authorEmail != "" {
 		cmd.Args = append(
 			cmd.Args,
-			fmt.Sprintf("-a=\"%q <%q>\"", authorName, authorEmail))
+			fmt.Sprintf("--auther=\"%q <%q>\"", authorName, authorEmail))
 	}
 
 	return cmd


### PR DESCRIPTION
After some experiments, I ended up fixing #64 and furthermore removing some quote marks that were added by fmt.Sprintf using %q instead of %s. This implements the recommended pattern indicated in [the git documentation](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---authorltauthorgt).