### PR TITLE
feat: add rebase option to allow multiple pushes in matrix builds

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -70,3 +70,4 @@ An example of specifying the path to a repo:
 | author_name    | the name to use for the author of the commit (if blank, assume push commiter name)
 | author_email   | the email address to use for the author of the commit (if blank, assume push commiter name)
 | followtags     | push with --follow-tags option
+| rebase         | pull --rebase before pushing

--- a/main.go
+++ b/main.go
@@ -129,6 +129,11 @@ func main() {
 			Usage:   "bypasses the pre-commit and commit-msg hooks",
 			EnvVars: []string{"PLUGIN_NO_VERIFY", "GIT_PUSH_NO_VERIFY"},
 		},
+		&cli.BoolFlag{
+			Name:    "rebase",
+			Usage:   "pull rebase branch before push",
+			EnvVars: []string{"PLUGIN_REBASE", "GIT_PUSH_REBASE"},
+		},
 	}
 
 	if BuildNum != "" {
@@ -168,6 +173,7 @@ func run(c *cli.Context) error {
 			Tag:           c.String("tag"),
 			EmptyCommit:   c.Bool("empty-commit"),
 			NoVerify:      c.Bool("no-verify"),
+			Rebase:        c.Bool("rebase"),
 		},
 	}
 

--- a/plugin.go
+++ b/plugin.go
@@ -41,6 +41,7 @@ type (
 		Tag           string
 		EmptyCommit   bool
 		NoVerify      bool
+		Rebase        bool
 	}
 
 	// Plugin Structure
@@ -82,6 +83,10 @@ func (p Plugin) Exec() error {
 	}
 
 	if err := p.HandleRemote(); err != nil {
+		return err
+	}
+
+	if err := p.HandleRebase(); err != nil {
 		return err
 	}
 
@@ -209,6 +214,22 @@ func (p Plugin) HandlePush() error {
 	)
 
 	return execute(repo.RemotePushNamedBranch(name, local, branch, force, followtags))
+}
+
+// HanldeRebase pull rebases before pushing
+func (p Plugin) HandleRebase() error {
+	if p.Config.Rebase {
+		var (
+			name   = p.Config.RemoteName
+			branch = p.Config.Branch
+		)
+
+		if err := execute(repo.RemotePullRebaseNamedBranch(name, branch)); err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
 // HandleCleanup does eventually do some cleanup.

--- a/repo/remote.go
+++ b/repo/remote.go
@@ -32,6 +32,17 @@ func RemotePush(remote, branch string, force bool, followtags bool) *exec.Cmd {
 	return RemotePushNamedBranch(remote, "HEAD", branch, force, followtags)
 }
 
+func RemotePullRebaseNamedBranch(remote, branch string) *exec.Cmd {
+	cmd := exec.Command(
+		"git",
+		"pull",
+		"--rebase",
+		remote,
+		branch)
+
+	return cmd
+}
+
 // RemotePushNamedBranch puchs changes from a local to a remote branch.
 func RemotePushNamedBranch(remote, localbranch string, branch string, force bool, followtags bool) *exec.Cmd {
 	cmd := exec.Command(


### PR DESCRIPTION
I created a pr that adds the options to rebase the push branch with the remote before pushing. This is helpful if the plugin is executed in a matrix build.

In oder to make rebasing work you need to also increase the depth.