### PR TITLE
feat: add support and documentation for remote repository mirroring

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -51,6 +51,18 @@ An example of specifying the path to a repo:
     path: path/to/repo
 ```
 
+An example of mirroring all refs to a remote repository:
+
+```yaml
+- name: mirror push
+  image: appleboy/drone-git-push
+  settings:
+    remote: git@github.com:foo/bar-mirror.git
+    mirror: true
+    ssh_key:
+      from_secret: deploy_key
+```
+
 ## Parameter Reference
 
 | setting        | description
@@ -71,3 +83,4 @@ An example of specifying the path to a repo:
 | author_email   | the email address to use for the author of the commit (if blank, assume push commiter name)
 | followtags     | push with --follow-tags option
 | rebase         | pull --rebase before pushing
+| mirror         | push all refs to remote repository with --mirror, defaults to false

--- a/README.md
+++ b/README.md
@@ -46,3 +46,17 @@ docker run --rm \
   -w "$(pwd)" \
   appleboy/drone-git-push
 ```
+
+Mirror all refs to a remote repository:
+
+```sh
+docker run --rm \
+  -e DRONE_COMMIT_AUTHOR=Octocat \
+  -e DRONE_COMMIT_AUTHOR_EMAIL=octocat@github.com \
+  -e PLUGIN_SSH_KEY="$(cat "${HOME}/.ssh/id_rsa")" \
+  -e PLUGIN_REMOTE=git@github.com:foo/bar.git \
+  -e PLUGIN_MIRROR=true \
+  -v "$(pwd):$(pwd)" \
+  -w "$(pwd)" \
+  appleboy/drone-git-push
+```

--- a/README.zh-cn.md
+++ b/README.zh-cn.md
@@ -1,10 +1,10 @@
-
 # drone-git-push
 
 [English](README.md) | [繁體中文](README.zh-tw.md)
 
 [![GoDoc](https://godoc.org/github.com/appleboy/drone-git-push?status.svg)](https://godoc.org/github.com/appleboy/drone-git-push)
 [![Lint and Testing](https://github.com/appleboy/drone-git-push/actions/workflows/testing.yml/badge.svg)](https://github.com/appleboy/drone-git-push/actions/workflows/testing.yml)
+[![Trivy Security Scan](https://github.com/appleboy/drone-git-push/actions/workflows/trivy.yml/badge.svg)](https://github.com/appleboy/drone-git-push/actions/workflows/trivy.yml)
 [![codecov](https://codecov.io/gh/appleboy/drone-git-push/branch/master/graph/badge.svg)](https://codecov.io/gh/appleboy/drone-git-push)
 [![Go Report Card](https://goreportcard.com/badge/github.com/appleboy/drone-git-push)](https://goreportcard.com/report/github.com/appleboy/drone-git-push)
 [![Docker Pulls](https://img.shields.io/docker/pulls/appleboy/drone-git-push.svg)](https://hub.docker.com/r/appleboy/drone-git-push/)
@@ -15,3 +15,48 @@
 ## 构建
 
 使用以下命令构建二进制文件：
+
+```sh
+go build
+go test
+```
+
+## Docker
+
+使用以下命令构建 Docker 镜像：
+
+```sh
+GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -a -tags netgo -o release/linux/amd64/drone-git-push
+docker build --rm -t appleboy/drone-git-push .
+```
+
+## 使用方式
+
+从工作目录执行：
+
+```sh
+docker run --rm \
+  -e DRONE_COMMIT_AUTHOR=Octocat \
+  -e DRONE_COMMIT_AUTHOR_EMAIL=octocat@github.com \
+  -e PLUGIN_SSH_KEY="$(cat "${HOME}/.ssh/id_rsa")" \
+  -e PLUGIN_BRANCH=master \
+  -e PLUGIN_REMOTE=git@github.com:foo/bar.git \
+  -e PLUGIN_FORCE=false \
+  -v "$(pwd):$(pwd)" \
+  -w "$(pwd)" \
+  appleboy/drone-git-push
+```
+
+镜像所有 refs 到远程仓库：
+
+```sh
+docker run --rm \
+  -e DRONE_COMMIT_AUTHOR=Octocat \
+  -e DRONE_COMMIT_AUTHOR_EMAIL=octocat@github.com \
+  -e PLUGIN_SSH_KEY="$(cat "${HOME}/.ssh/id_rsa")" \
+  -e PLUGIN_REMOTE=git@github.com:foo/bar.git \
+  -e PLUGIN_MIRROR=true \
+  -v "$(pwd):$(pwd)" \
+  -w "$(pwd)" \
+  appleboy/drone-git-push
+```

--- a/README.zh-tw.md
+++ b/README.zh-tw.md
@@ -1,10 +1,10 @@
-
 # drone-git-push
 
 [English](README.md) | [简体中文](README.zh-cn.md)
 
 [![GoDoc](https://godoc.org/github.com/appleboy/drone-git-push?status.svg)](https://godoc.org/github.com/appleboy/drone-git-push)
 [![Lint and Testing](https://github.com/appleboy/drone-git-push/actions/workflows/testing.yml/badge.svg)](https://github.com/appleboy/drone-git-push/actions/workflows/testing.yml)
+[![Trivy Security Scan](https://github.com/appleboy/drone-git-push/actions/workflows/trivy.yml/badge.svg)](https://github.com/appleboy/drone-git-push/actions/workflows/trivy.yml)
 [![codecov](https://codecov.io/gh/appleboy/drone-git-push/branch/master/graph/badge.svg)](https://codecov.io/gh/appleboy/drone-git-push)
 [![Go Report Card](https://goreportcard.com/badge/github.com/appleboy/drone-git-push)](https://goreportcard.com/report/github.com/appleboy/drone-git-push)
 [![Docker Pulls](https://img.shields.io/docker/pulls/appleboy/drone-git-push.svg)](https://hub.docker.com/r/appleboy/drone-git-push/)
@@ -15,3 +15,48 @@
 ## 建置
 
 使用以下命令建置二進位檔：
+
+```sh
+go build
+go test
+```
+
+## Docker
+
+使用以下命令建置 Docker 映像檔：
+
+```sh
+GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -a -tags netgo -o release/linux/amd64/drone-git-push
+docker build --rm -t appleboy/drone-git-push .
+```
+
+## 使用方式
+
+從工作目錄執行：
+
+```sh
+docker run --rm \
+  -e DRONE_COMMIT_AUTHOR=Octocat \
+  -e DRONE_COMMIT_AUTHOR_EMAIL=octocat@github.com \
+  -e PLUGIN_SSH_KEY="$(cat "${HOME}/.ssh/id_rsa")" \
+  -e PLUGIN_BRANCH=master \
+  -e PLUGIN_REMOTE=git@github.com:foo/bar.git \
+  -e PLUGIN_FORCE=false \
+  -v "$(pwd):$(pwd)" \
+  -w "$(pwd)" \
+  appleboy/drone-git-push
+```
+
+鏡像所有 refs 到遠端儲存庫：
+
+```sh
+docker run --rm \
+  -e DRONE_COMMIT_AUTHOR=Octocat \
+  -e DRONE_COMMIT_AUTHOR_EMAIL=octocat@github.com \
+  -e PLUGIN_SSH_KEY="$(cat "${HOME}/.ssh/id_rsa")" \
+  -e PLUGIN_REMOTE=git@github.com:foo/bar.git \
+  -e PLUGIN_MIRROR=true \
+  -v "$(pwd):$(pwd)" \
+  -w "$(pwd)" \
+  appleboy/drone-git-push
+```

--- a/main.go
+++ b/main.go
@@ -161,6 +161,11 @@ func main() {
 			Usage:   "pull rebase branch before push",
 			EnvVars: []string{"PLUGIN_REBASE", "GIT_PUSH_REBASE", "INPUT_REBASE"},
 		},
+		&cli.BoolFlag{
+			Name:    "mirror",
+			Usage:   "push all refs to remote repository with --mirror",
+			EnvVars: []string{"PLUGIN_MIRROR", "GIT_PUSH_MIRROR", "INPUT_MIRROR"},
+		},
 	}
 
 	if err := app.Run(os.Args); err != nil {
@@ -197,6 +202,7 @@ func run(c *cli.Context) error {
 			EmptyCommit:   c.Bool("empty-commit"),
 			NoVerify:      c.Bool("no-verify"),
 			Rebase:        c.Bool("rebase"),
+			Mirror:        c.Bool("mirror"),
 		},
 	}
 

--- a/plugin.go
+++ b/plugin.go
@@ -43,6 +43,7 @@ type (
 		EmptyCommit   bool
 		NoVerify      bool
 		Rebase        bool
+		Mirror        bool
 	}
 
 	// Plugin Structure
@@ -206,6 +207,10 @@ func (p Plugin) HandleTag(ctx context.Context) error {
 
 // HandlePush pushs the changes to the remote repo.
 func (p Plugin) HandlePush(ctx context.Context) error {
+	if p.Config.Mirror {
+		return execute(repo.RemotePushMirror(ctx, p.Config.RemoteName))
+	}
+
 	var (
 		name       = p.Config.RemoteName
 		local      = p.Config.LocalBranch

--- a/repo/remote.go
+++ b/repo/remote.go
@@ -93,3 +93,18 @@ func RemotePushNamedBranch(
 
 	return cmd
 }
+
+// RemotePushMirror pushes all refs to remote repository using --mirror.
+func RemotePushMirror(ctx context.Context, remote string) *exec.Cmd {
+	sanitizedRemote := sanitizeInput(remote)
+
+	cmd := exec.CommandContext(
+		ctx,
+		"git",
+		"push",
+		"--mirror",
+		sanitizedRemote,
+	)
+
+	return cmd
+}


### PR DESCRIPTION
- Add support for mirroring all refs to a remote repository with the --mirror flag
- Document new mirror usage in English and Chinese README files
- Update parameter references to include mirror option
- Show example configuration for remote mirror push
- Add Trivy Security Scan badge to Chinese README files

fix https://github.com/appleboy/drone-git-push/issues/47